### PR TITLE
Add Right to Decline

### DIFF
--- a/text.mustache.md
+++ b/text.mustache.md
@@ -16,7 +16,7 @@ These terms add to the terms of the license for this software.  These terms beco
 {{#license}}
 ## Purpose
 
-This license gives everyone as much permission to work with this software as possible, while protecting contributors from liability and requiring credit for their work.
+This license gives everyone as much permission to work with this software as possible, while protecting contributors from liability and requiring that they be credited.
 
 ## Acceptance
 

--- a/text.mustache.md
+++ b/text.mustache.md
@@ -55,6 +55,10 @@ If widespread convention dictates a particular way to give credit for your kind 
 
 If this software includes software and contributor names to credit in a standard way, such as in software package metadata or on an "about" page or screen, you may rely on that information for accuracy and completeness in giving credit.  If this software does not include names to credit in a standard way, but includes a link to a webpage for this software, you must investigate that webpage for names to credit.  If this software provides neither names to credit nor a software-webpage link, you do not have to perform independent research to find names to credit.
 
+## Right to Decline
+
+On written request from a contributor, you must remove their credit for works they do not want to be associated with.  On written request from all contributors to this software, you must remove credit for this software.
+
 {{#license}}
 ## Reliability
 

--- a/text.mustache.md
+++ b/text.mustache.md
@@ -57,7 +57,7 @@ If this software includes software and contributor names to credit in a standard
 
 ## Right to Decline
 
-On written request from a contributor, you must remove their credit for works they do not want to be associated with.  On written request from all contributors to this software, you must remove credit for this software.
+On written request from a contributor, you must remove their name from any credits you make available for works they do not want to be associated with going forward.  On written request from all contributors to this software, you must do the same for the name of this software.
 
 {{#license}}
 ## Reliability


### PR DESCRIPTION
This pull request adds a new, short section that gives contributors and projects the right to decline credit for works they don't want to be associated with.

In cases where contributors discover a work after they've been credited, declining credit will be largely symbolic, but experience shows that symbolism can be extremely important.

For those in need of another Wikipedia rabbit hole, here's a place to start: https://en.wikipedia.org/wiki/Alan_Smithee