### PR TITLE
pronoun usage to indicate project roles

### DIFF
--- a/text.mustache.md
+++ b/text.mustache.md
@@ -16,7 +16,7 @@ These terms add to the terms of the license for this software.  These terms beco
 {{#license}}
 ## Purpose
 
-This license gives everyone as much permission to work with this software as possible, while protecting contributors from liability and requiring that they be credited.
+I, the creator of this software, license to you, the user, as much permission to work with this software as possible, while protecting myself and contributors from liability and requiring credit for our work.
 
 ## Acceptance
 
@@ -24,7 +24,7 @@ In order to receive this license, you must agree to its rules.  The rules of thi
 
 ## Copyright
 
-Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.
+As the creator and contributors of this software, we license you to do everything with this software that would otherwise infringe on our copyright in it.
 
 ## Notices
 
@@ -35,34 +35,33 @@ You must ensure that everyone who gets a copy of any part of this software from 
 If anyone notifies you in writing that you have not complied with [Notices](#notices) or [Credit](#credit), you can keep your license by taking all practical steps to comply within 30 days after the notice.  If you do not do so, your license ends immediately.
 
 ## Patent
-
-Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
+As the creator and contributors of this software, we license you to do everything with this software that would otherwise infringe any patent claims we can license or become able to license.
 {{/license}}
 
 ## Credit
 
-You must give this software and each contributor credit for contribution to other works, be they goods or services, that you produce or provide using this software.
+As a user or distributor, you must give us, the creator and contributors of this software, and this software credit for contribution to your works, be they goods or services, that you produce or provide using this software.
 
 ## How to Credit
 
-In general, you must give credit in such a way that the audience for your work can freely and readily find a written notice identifying this software, by name, as a contribution to your work, as well as each contributor, by name, as a contributor to this software.  You must not do anything to stop the audience for your work from sharing, publishing, or using credits.
+In general, you must give credit in such a way that the audience for your work can freely and readily find a written notice identifying this software, by name, as a contribution to your work, as well as each of us, by name, as the creator and contributors to this software.  You must not do anything to stop the audience for your work from sharing, publishing, or using credits.
 
 ## Conventions
 
 If widespread convention dictates a particular way to give credit for your kind of work, such as by end credit, citation, acknowledgment, or billing, then follow that convention.  For software provided in copies to run or install, give credit in documentation and notice files.  For software provided as a web service, give credits in `credits.txt`, according to <https://creditstxt.com>.
 
-## Who to Credit
-
-If this software includes software and contributor names to credit in a standard way, such as in software package metadata or on an "about" page or screen, you may rely on that information for accuracy and completeness in giving credit.  If this software does not include names to credit in a standard way, but includes a link to a webpage for this software, you must investigate that webpage for names to credit.  If this software provides neither names to credit nor a software-webpage link, you do not have to perform independent research to find names to credit.
-
 ## Right to Decline
 
 On written request from a contributor, you must remove their name from any credits you make available for works they do not want to be associated with going forward.  On written request from all contributors to this software, you must do the same for the name of this software.
 
+## Who to Credit
+
+If this software includes software and contributor names to credit in a standard way, such as in software package metadata or on an "about" page or screen, you may rely on that information for accuracy and completeness in giving credit.  If this software does not include names to credit in a standard way, but includes a link to a webpage for this software, you must investigate that webpage for names to credit.  If this software provides neither names to credit nor a software-webpage link, you do not have to perform independent research to find names to credit.
+
 {{#license}}
 ## Reliability
 
-No contributor can revoke this license.
+Neither I the creator, nor any contributor, can revoke this license.
 
 ## No Liability
 


### PR DESCRIPTION
 - I/me/my: the original author/creator of the project
 - they/them/their: (currently no instances, I believe) the collective of contributors to this project who are not the original author/creator.
 - We/us/our: the collective of the original author/creator and the 
 - you/your: the user or distributor of the project, synonymously, the creator of another project which depends on this one

@kemitchell PR as requested.